### PR TITLE
docs(readme): fix mermaid flowchart label to render on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ sequenceDiagram
 ### Components
 ```mermaid
 flowchart LR
-    C[Client Agent] -->|HTTP (x402 JSON)| M[Merchant Service]
+    C[Client Agent] -->|HTTP x402 JSON| M[Merchant Service]
     M -->|verify/settle| F[Facilitator]
-    F -->|JSON-RPC| T[USDT0 (EIP-3009) on Plasma]
+    F -->|JSON-RPC| T[USDT0 EIP-3009 on Plasma]
 ```
 ## Directory quick map
 - contracts/ — Solidity sources (Ethereum + Plasma)


### PR DESCRIPTION
Fixes a Mermaid parsing error by removing parentheses from an edge label and simplifying a node label, ensuring the diagram renders on GitHub.

- Edge: "HTTP (x402 JSON)" → "HTTP x402 JSON"
- Node: "USDT0 (EIP-3009) on Plasma" → "USDT0 EIP-3009 on Plasma"

Docs-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated diagram labels in documentation for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->